### PR TITLE
Add support for libravatar.org

### DIFF
--- a/hyperkitty/templates/user_profile.html
+++ b/hyperkitty/templates/user_profile.html
@@ -67,8 +67,8 @@
         </form>
 
         <div class="gravatar">
-            <a href="http://gravatar.com/">{% gravatar user.email 150 %}</a>
-            <p><a href="http://gravatar.com/">Edit on gravatar.com</a></p>
+            <a href="{{ gravatar_url }}">{% gravatar user.email 150 %}</a>
+            <p><a href="{{ gravatar_url }}">Edit on {{ gravatar_shortname }}</a></p>
         </div>
 
     <div class="clearfix"></div>

--- a/hyperkitty/views/accounts.py
+++ b/hyperkitty/views/accounts.py
@@ -138,12 +138,19 @@ def user_profile(request):
                       "msg": FLASH_MESSAGES[flash_msg][1] }
         flash_messages.append(flash_msg)
 
+    # Extract the gravatar_url used by django_gravatar2.  The site
+    # administrator could alternatively set this to http://cdn.libravatar.org/
+    gravatar_url = getattr(settings, 'GRAVATAR_URL', 'http://www.gravatar.com')
+    gravatar_shortname = '.'.join(gravatar_url.split('.')[-2:]).strip('/')
+
     context = {
         'user_profile' : user_profile,
         'form': form,
         'emails': emails,
         'favorites': favorites,
         'flash_messages': flash_messages,
+        'gravatar_url': gravatar_url,
+        'gravatar_shortname': gravatar_shortname,
     }
     return render(request, "user_profile.html", context)
 


### PR DESCRIPTION
django_gravatar2 is already configurable such that it can be pointed at the Free as in Libre service http://www.libravatar.org instead of http://gravatar.com/

This patch removes the one place in hyperkitty where "gravatar.com" was hardcoded.  It now pulls its strings from those same settings.

Tested locally.
