### PR TITLE
templatizing strings for translation

### DIFF
--- a/hyperkitty/templates/hyperkitty/404.html
+++ b/hyperkitty/templates/hyperkitty/404.html
@@ -25,12 +25,12 @@
 
         <div style="margin: 60px 40px 0 40px;">
             <div id="contentBox" style="width:50%; ">
-                <span class="hello"> 404 </span>
+                <span class="hello"> {% trans "Error 404" %} </span>
                 <br/><br/>
-                <span style="font-size:60px; color:#444;font-family: 'Times New Roman';"> Oh! Snap </span> 
+                <span style="font-size:60px; color:#444;font-family: 'Times New Roman';"> {% trans "Oh No!" %} </span>
                 <br/><br/>
-                <p>I can't find this page.</p>
-                <a href ="{% url 'hk_root' %}">Go back home</a>
+                <p>{% trans "I can't find this page." %}</p>
+                <a href ="{% url 'hk_root' %}">{% trans "Go back home" %}</a>
             </div>
         </div>
 

--- a/hyperkitty/templates/hyperkitty/500.html
+++ b/hyperkitty/templates/hyperkitty/500.html
@@ -26,12 +26,12 @@
 
         <div style="margin: 60px 40px 0 40px;">
             <div id="contentBox" style="width:50%; ">
-                <span class="hello"> 500 </span>
+                <span class="hello"> {% trans "Error 500" %} </span>
                 <br/><br/>
-                <span style="font-size:60px; color:#444;font-family: 'Times New Roman';"> Oh! Snap </span> 
+                <span style="font-size:60px; color:#444;font-family: 'Times New Roman';"> {% trans "Oh No!" %} </span>
                 <br/><br/>
-                <p>Sorry, but the requested page is unavailable due to a server hiccup.</p>
-                <a href ="{% url 'hk_root' %}">Go back home</a>
+                <p>{% trans "Sorry, but the requested page is unavailable due to a server hiccup." %}</p>
+                <a href ="{% url 'hk_root' %}">{% trans "Go back home" %}</a>
             </div>
         </div>
 

--- a/hyperkitty/templates/hyperkitty/ajax/last_views.html
+++ b/hyperkitty/templates/hyperkitty/ajax/last_views.html
@@ -14,19 +14,19 @@
                     <td>
                         {% with num_unread=lv.num_unread starting_email=lv.thread.starting_email %}
                         {% if num_unread %}
-                        <i class="unread icon-eye-close" title="New comments"></i>
+                        <i class="unread icon-eye-close" title="{% trans 'New comments' %}"></i>
                         {% endif %}
                         <a href="{% url 'hk_thread' mlist_fqdn=lv.thread.mailinglist.name threadid=lv.thread.thread_id %}"
                             >{{ starting_email.subject }}</a>
                         <br>
-                        Original author: {{ starting_email.sender.name }}
+                        {% trans "Original author:" %} {{ starting_email.sender.name }}
                         <br>
-                        Started on: {{ starting_email.date|date:"D, j M Y H:i" }}
+                        {% trans "Started on:" %} {{ starting_email.date|date:"D, j M Y H:i" }}
                         <br>
-                        Last activity: {{ lv.thread.date_active|timesince }}
+                        {% trans "Last activity:" %} {{ lv.thread.date_active|timesince }}
                         <br>
-                        Replies: {{ lv.thread|num_comments }}
-                        {% if num_unread %} / {{ num_unread }} new {% endif %}
+                        {% trans "Replies:" %} {{ lv.thread|num_comments }}
+                        {% if num_unread %} / {{ num_unread }} {% trans "new" %} {% endif %}
                         {% endwith %}
                     </td>
                 </tr>
@@ -37,12 +37,12 @@
             <thead>
                 <tr>
                     <th></th>
-                    <th>List</th>
-                    <th>Subject</th>
-                    <th>Original author</th>
-                    <th>Start date</th>
-                    <th>Last activity</th>
-                    <th>Replies</th>
+                    <th>{% trans "List" %}</th>
+                    <th>{% trans "Subject" %}</th>
+                    <th>{% trans "Original author" %}</th>
+                    <th>{% trans "Start date" %}</th>
+                    <th>{% trans "Last activity" %}</th>
+                    <th>{% trans "Replies" %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -51,7 +51,7 @@
                     {% with num_unread=lv.num_unread starting_email=lv.thread.starting_email %}
                     <td>
                         {% if num_unread %}
-                        <i class="unread icon-eye-close" title="New comments"></i>
+                        <i class="unread icon-eye-close" title="{% trans 'New comments' %}"></i>
                         {% endif %}
                     </td>
                     <td>
@@ -65,7 +65,7 @@
                     <td>{{ lv.thread.date_active|timesince }}</td>
                     <td>
                         {{ lv.thread|num_comments }}
-                        {% if num_unread %} / {{ num_unread }} new {% endif %}
+                        {% if num_unread %} / {{ num_unread }} {% trans "new" %} {% endif %}
                     </td>
                     {% endwith %}
                 </tr>
@@ -74,5 +74,5 @@
         </table>
         {% include "hyperkitty/paginator.html" with pager=last_views page_key="lvpage" %}
     {% else %}
-        <p>Nothing read yet.</p>
+        <p>{% trans "Nothing read yet." %}</p>
     {% endif %}

--- a/hyperkitty/templates/hyperkitty/ajax/reattach_suggest.html
+++ b/hyperkitty/templates/hyperkitty/ajax/reattach_suggest.html
@@ -3,10 +3,10 @@
                 {% for s_thread in suggested_threads %}
                 <li><label class="radio"><input type="radio" name="parent" value="{{ s_thread.thread_id }}" />
                     {{ s_thread.subject }}
-                    <br/>(started {{ s_thread.starting_email.date }}, last active: {{ s_thread.date_active }},
-                    <a href="{% url 'hk_thread' mlist_fqdn=mlist.name threadid=s_thread.thread_id %}">see this thread</a>)
+                    <br/>({% trans "started" %} {{ s_thread.starting_email.date }}, {% trans "last active:" %} {{ s_thread.date_active }},
+                    <a href="{% url 'hk_thread' mlist_fqdn=mlist.name threadid=s_thread.thread_id %}">{% trans "see this thread" %}</a>)
                     </label>
                 </li>
                 {% empty %}
-                <li><em>(no suggestions)</em></li>
+                <li><em>{% trans "(no suggestions)" %}</em></li>
                 {% endfor %}

--- a/hyperkitty/templates/hyperkitty/ajax/reattach_suggest.html
+++ b/hyperkitty/templates/hyperkitty/ajax/reattach_suggest.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load hk_generic %}
 
                 {% for s_thread in suggested_threads %}

--- a/hyperkitty/templates/hyperkitty/ajax/replies.html
+++ b/hyperkitty/templates/hyperkitty/ajax/replies.html
@@ -1,4 +1,6 @@
 {% load cycle from future %}
+{% load url from future %}
+{% load i18n %}
 {% load hk_generic %}
 
                 {% for email in replies %}

--- a/hyperkitty/templates/hyperkitty/ajax/temp_message.html
+++ b/hyperkitty/templates/hyperkitty/ajax/temp_message.html
@@ -8,7 +8,7 @@
 
         <div class="email-header">
             <div class="email-date inline-block pull-right">
-                <span class="date">Sent just now, not yet distributed</span>
+                <span class="date">{% trans "Sent just now, not yet distributed" %}</span>
             </div>
             <div class="gravatar{% if use_mockups %} pull-left{% endif %}">
                 {% gravatar user.email 40 %}
@@ -18,7 +18,7 @@
                 {% if use_mockups %}
                 <br />
                 <span class="rank">
-                    Rank 8
+                    {% trans "Rank 8" %}
                 </span>
                 {% endif %}
             </div>

--- a/hyperkitty/templates/hyperkitty/ajax/temp_message.html
+++ b/hyperkitty/templates/hyperkitty/ajax/temp_message.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/ajax/votes.html
+++ b/hyperkitty/templates/hyperkitty/ajax/votes.html
@@ -15,20 +15,20 @@
                         <a href="{% url 'hk_message_index' mlist_fqdn=vote.email.mailinglist.name message_id_hash=vote.email.message_id_hash %}"
                             >{{ vote.email.subject }}</a>
                         <br>
-                        Original author: {{ vote.email.sender.name }}
+                        {% trans "Original author:" %} {{ vote.email.sender.name }}
                         <br>
-                        Started on: {{ vote.email.date|date:"D, j M Y H:i" }}
+                        {% trans "Started on:" %} {{ vote.email.date|date:"D, j M Y H:i" }}
                         <br>
                         <form method="post" class="likeform"
                               action="{% url 'hk_message_vote' mlist_fqdn=vote.email.mailinglist.name message_id_hash=vote.email.message_id_hash %}">
                             {% csrf_token %}
                             <input type="hidden" name="vote" value="0" />
                             {% if vote.value == 1 %}
-                            <span class="youlike">You like it
+                            <span class="youlike">{% trans "You like it" %}
                             {% elif vote.value == -1 %}
-                            <span class="youdislike">You dislike it
+                            <span class="youdislike">{% trans "You dislike it" %}
                             {% endif %}
-                            (<a href="#cancelvote" class="cancel">cancel</a>)</span>
+                            (<a href="#cancelvote" class="cancel">{% trans "cancel" %}</a>)</span>
                         </form>
                     </td>
                 </tr>
@@ -37,11 +37,11 @@
         <table class="table table-striped table-bordered table-condensed hidden-tn hidden-xs">
             <thead>
                 <tr>
-                    <th>List</th>
-                    <th>Subject</th>
-                    <th>Original author</th>
-                    <th>Start date</th>
-                    <th>Vote</th>
+                    <th>{% trans "List" %}</th>
+                    <th>{% trans "Subject" %}</th>
+                    <th>{% trans "Original author" %}</th>
+                    <th>{% trans "Start date" %}</th>
+                    <th>{% trans "Vote" %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -61,11 +61,11 @@
                             {% csrf_token %}
                             <input type="hidden" name="vote" value="0" />
                             {% if vote.value == 1 %}
-                            <span class="youlike">You like it
+                            <span class="youlike">{% trans "You like it" %}
                             {% elif vote.value == -1 %}
-                            <span class="youdislike">You dislike it
+                            <span class="youdislike">{% trans "You dislike it" %}
                             {% endif %}
-                            (<a href="#cancelvote" class="cancel">cancel</a>)</span>
+                            (<a href="#cancelvote" class="cancel">{% trans "cancel" %}</a>)</span>
                         </form>
                     </td>
                 </tr>
@@ -74,5 +74,5 @@
         </table>
         {% include "hyperkitty/paginator.html" with pager=votes page_key="vpage" %}
     {% else %}
-        <p>No vote yet.</p>
+        <p>{% trans "No vote yet." %}</p>
     {% endif %}

--- a/hyperkitty/templates/hyperkitty/api.html
+++ b/hyperkitty/templates/hyperkitty/api.html
@@ -1,61 +1,61 @@
 {% extends "hyperkitty/base.html" %}
 
 {% block content %}
-    <h2>REST API</h2>
+    <h2>{% trans "REST API" %}</h2>
     <p>
-        HyperKitty comes with a small REST API allowing you to programatically retrieve 
-        emails and information.
+        {% trans "HyperKitty comes with a small REST API allowing you to programatically retrieve
+        emails and information." %}
     </p>
 
-    <h3>Formats</h3>
+    <h3>{% trans "Formats" %}</h3>
     <p>
-        This REST API can return the information into several formats.
-        The default format is html to allow human readibility.<br />
-        To change the format, just add
-        <em>?format=&lt;FORMAT&gt;</em> to the url
+        {% trans "This REST API can return the information into several formats.
+        The default format is html to allow human readibility." %}<br />
+        {% trans 'To change the format, just add
+        <em>?format=&lt;FORMAT&gt;</em> to the URL.' %}
     </p>
-    <p>The list of available formats is:</p>
+    <p>{% trans "The list of available formats is:" %}</p>
     <ul>
         <li>json <tt>(?format=json)</tt></li>
         <li>json-p <tt>(?format=json-p)</tt></li>
-        <li>txt <tt>(?format=txt)</tt></li>
+        <li>{% trans "Plain text" %} <tt>(?format=txt)</tt></li>
         <li>xml <tt>(?format=xml)</tt></li>
         <li>html <tt>(?format=html)</tt></li>
         <li>xhtml <tt>(?format=xhtml)</tt></li>
     </ul>
 
-    <h3>List of mailing-lists</h3>
-    <p>Endpoint: <tt>{% url 'hk_api_mailinglist_list' %}</tt></p>
+    <h3>{% trans "List of mailing-lists" %}</h3>
+    <p>{% trans "Endpoint:" %} <tt>{% url 'hk_api_mailinglist_list' %}</tt></p>
     <p>
-        Using this address you will be able to retrieve the information
-        known about all the mailing-lists.
+        {% trans "Using this address you will be able to retrieve the information
+        known about all the mailing lists." %}
     </p>
 
-    <h3>Threads in a mailing-list</h3>
-    <p>Endpoint: <tt>{% url 'hk_api_thread_list' mlist_fqdn='list-address@example.com' %}</tt></p>
+    <h3>{% trans "Threads in a mailing list" %}</h3>
+    <p>{% trans "Endpoint:" %} <tt>{% url 'hk_api_thread_list' mlist_fqdn='list-address@example.com' %}</tt></p>
     <p>
-        Using this address you will be able to retrieve information about
-        all the threads on the specified mailing-list.
+        {% trans "Using this address you will be able to retrieve information about
+        all the threads on the specified mailing list." %}
     </p>
 
-    <h3>Emails in a thread</h3>
-    <p>Endpoint: <tt>{% url 'hk_api_thread_email_list' mlist_fqdn='list-address@example.com' thread_id='THREAD-ID' %}</tt></p>
+    <h3>{% trans "Emails in a thread" %}</h3>
+    <p>{% trans "Endpoint:" %} <tt>{% url 'hk_api_thread_email_list' mlist_fqdn='list-address@example.com' thread_id='THREAD-ID' %}</tt></p>
     <p>
-        Using this address you will be able to retrieve the list of emails
-        in a mailing-list thread.
+        {% trans "Using this address you will be able to retrieve the list of emails
+        in a mailing list thread." %}
     </p>
 
-    <h3>An email in a mailing-list</h3>
-    <p>Endpoint: <tt>{% url 'hk_api_email_detail' mlist_fqdn='list-address@example.com' message_id_hash='MESSAGE-ID-HASH' %}</tt></p>
+    <h3>{% trans "An email in a mailing list" %}</h3>
+    <p>{% trans "Endpoint:" %} <tt>{% url 'hk_api_email_detail' mlist_fqdn='list-address@example.com' message_id_hash='MESSAGE-ID-HASH' %}</tt></p>
     <p>
-        Using this address you will be able to retrieve the information
-        known about a specific email on the specified mailing-list.
+        {% trans "Using this address you will be able to retrieve the information
+        known about a specific email on the specified mailing list." %}
     </p>
 
-    <h3>Tags</h3>
-    <p>Endpoint: <tt>{% url 'hk_api_tag_list' %}</tt></p>
+    <h3>{% trans "Tags" %}</h3>
+    <p>{% trans "Endpoint:" %} <tt>{% url 'hk_api_tag_list' %}</tt></p>
     <p>
-        Using this address you will be able to retrieve the list of tags.
+        {% trans "Using this address you will be able to retrieve the list of tags." %}
     </p>
 
 {% endblock %}

--- a/hyperkitty/templates/hyperkitty/api.html
+++ b/hyperkitty/templates/hyperkitty/api.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load i18n %}
+{% load url from future %}
 
 {% block content %}
     <h2>{% trans "REST API" %}</h2>

--- a/hyperkitty/templates/hyperkitty/base.html
+++ b/hyperkitty/templates/hyperkitty/base.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load compress %}
 <!DOCTYPE HTML>
 <html>
@@ -18,7 +20,6 @@
         {% endcompress %}
         {% block additional_stylesheets %} {% endblock %}
     </head>
-    {% load i18n %}
 
     <body>
 

--- a/hyperkitty/templates/hyperkitty/base.html
+++ b/hyperkitty/templates/hyperkitty/base.html
@@ -41,28 +41,28 @@
                         {% else %}
                         >
                         {% endif %}
-                        <a href="{% url 'hk_root' %}">Lists</a>
+                        <a href="{% url 'hk_root' %}">{% trans "Lists" %}</a>
                     </li>
                     <li {% if '/categories' in request.path %}
                         class="active">
                         {% else %}
                         >
                         {% endif %}
-                        <a href="{% url 'hk_categories_overview' %}">Categories</a>
+                        <a href="{% url 'hk_categories_overview' %}">{% trans "Categories" %}</a>
                     </li>
                     <li {% if '/tags' in request.path %}
                         class="active">
                         {% else %}
                         >
                         {% endif %}
-                        <a href="{% url 'hk_tags_overview' %}">Tags</a>
+                        <a href="{% url 'hk_tags_overview' %}">{% trans "Tags" %}</a>
                     </li>
                     <li {% if '/users' in request.path %}
                         class="active">
                         {% else %}
                         >
                         {% endif %}
-                        <a href="{% url 'hk_users_overview' %}">Users</a>
+                        <a href="{% url 'hk_users_overview' %}">{% trans "Users" %}</a>
                     </li>
                     {% if postorius_installed %}
                     <li><a class="postorius" href="{{ postorius_installed }}">{% trans 'Manage lists' %}</a></li>
@@ -80,10 +80,10 @@
                     </button>
                     <ul class="dropdown-menu" role="menu" aria-labelledby="loginDropdownMenu">
                         {% if use_internal_auth %}
-                        <li role="presentation"><a role="menuitem" tabindex="-1" class="mm_user" href="{% url 'hk_user_login' %}?next={{next|default:request.path|urlencode}}">Login</a></li>
-                        <li role="presentation"><a role="menuitem" tabindex="-1" href="{% url 'hk_user_registration' %}?next={{next|default:request.path|urlencode}}"> Sign Up </a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" class="mm_user" href="{% url 'hk_user_login' %}?next={{next|default:request.path|urlencode}}">{% trans "Login" %}</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="{% url 'hk_user_registration' %}?next={{next|default:request.path|urlencode}}">{% trans "Sign Up" %}</a></li>
                         {% else %}
-                        <li role="presentation"><a role="menuitem" tabindex="-1" class="mm_logout" href="{% url 'hk_user_logout' %}?next={% url 'hk_root' %}">Logout</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" class="mm_logout" href="{% url 'hk_user_logout' %}?next={% url 'hk_root' %}">{% trans "Logout" %}</a></li>
                         <li role="presentation"><a role="menuitem" tabindex="-1" href="{% url 'hk_user_profile' %}">{{ user.username|truncatechars:"35" }}</a></li>
                         {% endif %}
                     </ul>
@@ -92,12 +92,12 @@
                 <!-- show regular list items for larger viewports (no dropdown)-->
                 <ul class="nav navbar-nav navbar-right auth">
                     {% if user.is_authenticated %}
-                        <li><a class="mm_logout hidden-sm" href="{% url 'hk_user_logout' %}?next={% url 'hk_root' %}">Logout</a></li>
+                        <li><a class="mm_logout hidden-sm" href="{% url 'hk_user_logout' %}?next={% url 'hk_root' %}">{% trans "Logout" %}</a></li>
                         <li><a class="hidden-sm" href="{% url 'hk_user_profile' %}">{{ user.username|truncatechars:"35" }}</a></li>
                     {% else %}
-                        <li><a class="mm_user {% if use_internal_auth %}hidden-sm{% endif %}" href="{% url 'hk_user_login' %}?next={{next|default:request.path|urlencode}}">Login</a></li>
+                        <li><a class="mm_user {% if use_internal_auth %}hidden-sm{% endif %}" href="{% url 'hk_user_login' %}?next={{next|default:request.path|urlencode}}">{% trans "Login" %}</a></li>
                         {% if use_internal_auth %}
-                        <li><a class="hidden-sm" href="{% url 'hk_user_registration' %}?next={{next|default:request.path|urlencode}}"> Sign Up </a></li>
+                        <li><a class="hidden-sm" href="{% url 'hk_user_registration' %}?next={{next|default:request.path|urlencode}}">{% trans "Sign Up" %}</a></li>
                         {% endif %}
                     {% endif %}
                 </ul>

--- a/hyperkitty/templates/hyperkitty/errors/notimplemented.html
+++ b/hyperkitty/templates/hyperkitty/errors/notimplemented.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load i18n %}
+{% load url from future %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/errors/notimplemented.html
+++ b/hyperkitty/templates/hyperkitty/errors/notimplemented.html
@@ -4,16 +4,16 @@
 
 
 {% block title %}
-Not implemented yet - {{ app_name|title }}
+{% trans "Not implemented yet" %} - {{ app_name|title }}
 {% endblock %}
 
 {% block content %}
 
-<h1>Not implemented</h1>
+<h1>{% trans "Not implemented" %}</h1>
 <p class="">
-    This feature has not been implemented yet, sorry.
+    {% trans "This feature has not been implemented yet, sorry." %}
     {% if mockup %}
-    It will <a class="" href="{{ mockup }}">look like this</a>.
+    {% trans 'It will <a class="" href="{{ mockup }}">look like this</a>.' %}
     {% endif %}
 </p>
 

--- a/hyperkitty/templates/hyperkitty/errors/private.html
+++ b/hyperkitty/templates/hyperkitty/errors/private.html
@@ -4,7 +4,7 @@
 
 
 {% block title %}
-Error: private list - {{ mlist.display_name|default:mlist.name|escapeemail }} - {{ app_name|title }}
+{% trans "Error: private list" %} - {{ mlist.display_name|default:mlist.name|escapeemail }} - {{ app_name|title }}
 {% endblock %}
 
 {% block content %}
@@ -16,7 +16,7 @@ Error: private list - {{ mlist.display_name|default:mlist.name|escapeemail }} - 
 
     <div class="col-sm-10">
         <p class="text-danger">
-            This mailing-list is private, you must be subscribed to view the archives.
+            {% trans "This mailing list is private. You must be subscribed to view the archives." %}
         </p>
     </div>
 

--- a/hyperkitty/templates/hyperkitty/errors/private.html
+++ b/hyperkitty/templates/hyperkitty/errors/private.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load i18n %}
+{% load url from future %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/errors/schemaupgrade.html
+++ b/hyperkitty/templates/hyperkitty/errors/schemaupgrade.html
@@ -2,7 +2,7 @@
 
 
 {% block title %}
-Error: the database schema needs an upgrade
+{% trans "Error: the database schema needs an upgrade" %}
     - {{ app_name|title }}
 {% endblock %}
 
@@ -15,11 +15,11 @@ Error: the database schema needs an upgrade
 
     <div class="col-sm-10">
         <p class="text-warning">
-            The database schema needs to be upgraded. Please refer to
+            {% trans 'The database schema needs to be upgraded. Please refer to
             <a href="http://hyperkitty.readthedocs.org/en/latest/install.html#upgrading">the documentation</a>
-            to perform this task.
+            to perform this task.' %}
         </p>
-        <p>When you're done, <a href="{% url 'hk_root' %}">go back</a> to the front page.</p>
+        <p>{% trans 'When you're done,' %} <a href="{% url 'hk_root' %}">{% trans "go back</a> to the front page." %}</p>
     </div>
 
 </div>

--- a/hyperkitty/templates/hyperkitty/errors/schemaupgrade.html
+++ b/hyperkitty/templates/hyperkitty/errors/schemaupgrade.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load i18n %}
+{% load url from future %}
 
 
 {% block title %}

--- a/hyperkitty/templates/hyperkitty/fragments/overview_threads.html
+++ b/hyperkitty/templates/hyperkitty/fragments/overview_threads.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 
 <div class="thread-list">
     {% for thread in threads %}

--- a/hyperkitty/templates/hyperkitty/fragments/overview_threads.html
+++ b/hyperkitty/templates/hyperkitty/fragments/overview_threads.html
@@ -3,7 +3,7 @@
     {% for thread in threads %}
         {% if forloop.counter == 6 %}
         <div class="bordered more-threads">
-        <a href="#">More...</a>
+        <a href="#">{% trans "More..." %}</a>
         {% endif %}
         {% include "hyperkitty/threads/summary_thread.html" with counter=forloop.counter %}
     {% empty %}

--- a/hyperkitty/templates/hyperkitty/fragments/user_subscriptions.html
+++ b/hyperkitty/templates/hyperkitty/fragments/user_subscriptions.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load hk_generic %}
 
     {% if subscriptions %}

--- a/hyperkitty/templates/hyperkitty/fragments/user_subscriptions.html
+++ b/hyperkitty/templates/hyperkitty/fragments/user_subscriptions.html
@@ -16,14 +16,14 @@
                         >{{ sub.first_post.subject }}</a>
                     <br>
                     <abbr title="{{ sub.first_post.date|date:"D, j M Y H:i"|escape }}">
-                    {{ sub.first_post.date|timesince }}</abbr> since first post
+                    {{ sub.first_post.date|timesince }}</abbr> {% trans "since first post" %}
                     <br>
-                    <a href="{{ sub.all_posts_url }}">{{ sub.posts_count }} post{{ sub.posts_count|pluralize }}</a><
+                    <a href="{{ sub.all_posts_url }}">{{ sub.posts_count }} {% trans "post" %}{{ sub.posts_count|pluralize }}</a><
                     <br>
                     <i class="icomoon likestatus {{ sub.likestatus }}"></i>
                     <span class="likestatus">+{{ sub.likes }}/-{{ sub.dislikes }}</span>
                 {% else %}
-                <td colspan="4" style="text-align:center"><em>no post yet</em>
+                <td colspan="4" style="text-align:center"><em>{% trans "no post yet" %}</em>
                 {% endif %}
                 </td>
             </tr>
@@ -33,11 +33,11 @@
     <table class="table table-striped table-bordered table-condensed subscriptions hidden-tn hidden-xs">
         <thead>
             <tr>
-                <th>List</th>
-                <th>Time since the first activity</th>
-                <th>First post</th>
-                <th>Posts to this list</th>
-                <th>Votes</th>
+                <th>{% trans "List" %}</th>
+                <th>{% trans "Time since the first activity" %}</th>
+                <th>{% trans "First post" %}</th>
+                <th>{% trans "Posts to this list" %}</th>
+                <th>{% trans "Votes" %}</th>
             </tr>
         </thead>
         <tbody>
@@ -55,18 +55,18 @@
                     <a href="{% url 'hk_message_index' mlist_fqdn=sub.list_name message_id_hash=sub.first_post.message_id_hash %}"
                         >{{ sub.first_post.subject }}</a>
                 </td>
-                <td><a href="{{ sub.all_posts_url }}">{{ sub.posts_count }} post{{ sub.posts_count|pluralize }}</a></td>
+                <td><a href="{{ sub.all_posts_url }}">{{ sub.posts_count }} {% trans "post" %}{{ sub.posts_count|pluralize }}</a></td>
                 <td>
                     <i class="icomoon likestatus {{ sub.likestatus }}"></i>
                     <span class="likestatus">+{{ sub.likes }}/-{{ sub.dislikes }}</span>
                 </td>
                 {% else %}
-                <td colspan="4" style="text-align:center"><em>no post yet</em></td>
+                <td colspan="4" style="text-align:center"><em>{% trans "no post yet" %}</em></td>
                 {% endif %}
             </tr>
         {% endfor %}
         </tbody>
     </table>
     {% else %}
-    <p><em>no subscriptions</em></p>
+    <p><em>{% trans "no subscriptions" %}</em></p>
     {% endif %}

--- a/hyperkitty/templates/hyperkitty/index.html
+++ b/hyperkitty/templates/hyperkitty/index.html
@@ -72,13 +72,13 @@
     <div class="col-tn-12 col-xs-7 col-md-8">
             {% if all_lists %}
             <p class="hide-switches">
-                <label><input type="checkbox" value="inactive" checked="checked" /> Hide inactive</label>
+                <label><input type="checkbox" value="inactive" checked="checked" />{% trans "Hide inactive" %}</label>
                 <label><input type="checkbox" value="private"
                         {% if sort_mode == "active" or sort_mode == "popular" %}
                         checked="checked" disabled="disabled"
-                        title="Private lists are always hidden in this sort mode"
+                        title="{% trans 'Private lists are always hidden in this sort mode' %}"
                         {% endif %}
-                        /> Hide private</label>
+                        />{% trans "Hide private" %}</label>
             </p>
             {% endif %}
     </div>
@@ -119,15 +119,15 @@
                              {% endif %}
                          </a>
                         {% if mlist.is_private %}
-                        <span class="list-tags">private</span>
+                        <span class="list-tags">{% trans "private" %}</span>
                         {% elif mlist.recent_threads_count == 0 %}
-                        <span class="list-tags">inactive</span>
+                        <span class="list-tags">{% trans "inactive" %}</span>
                         {% endif %}
                         <br />
                         <span class="list-description">{{ mlist.description|default_if_none:"" }}</span>
                         <span class="list-address hidden">{{ mlist.name }}</span>
                         <div class="chart">
-                            <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+                            <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
                         </div>
                         <ul class="list-stats list-unstyled">
                             <li>
@@ -155,7 +155,7 @@
             </tbody>
         </table> <!-- /table, main-content -->
         {% else %}
-        <p>No archived list yet.</p>
+        <p>{% trans "No archived list yet." %}</p>
         {% endif %}
     </div>
 </div> <!-- /row, for lists -->
@@ -196,9 +196,9 @@
                              {% endif %}
                          </a>
                         {% if mlist.is_private %}
-                        <span class="list-tags">private</span>
+                        <span class="list-tags">{% trans "private" %}</span>
                         {% elif mlist.recent_threads_count == 0 %}
-                        <span class="list-tags">inactive</span>
+                        <span class="list-tags">{% trans "inactive" %}</span>
                         {% endif %}
                         <br />
                         <span class="list-address">
@@ -210,7 +210,7 @@
                     </td>
                     <td class="activity">
                         <div class="chart">
-                            <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+                            <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
                         </div>
                         <ul class="list-stats list-unstyled">
                             <li>
@@ -238,7 +238,7 @@
             </tbody>
         </table> <!-- /table, main-content -->
         {% else %}
-        <p>No archived list yet.</p>
+        <p>{% trans "No archived list yet." %}</p>
         {% endif %}
 
     </div> <!-- /container for table -->

--- a/hyperkitty/templates/hyperkitty/login.html
+++ b/hyperkitty/templates/hyperkitty/login.html
@@ -18,13 +18,13 @@
 <div id="login">
 
 
-<h2>Login with your email</h2>
+<h2>{% trans "Login with your email" %}</h2>
 <ul class="social-login list-unstyled">
     {% csrf_token %}  {# necessary to set the token in a cookie #}
     <!-- Persona first -->
     {% browserid_info %}
     <li class="browserid">
-        {% browserid_login text='Login using Persona' color='blue' next=next %}
+        {% browserid_login text='{% trans "Login using Persona" %}' color='blue' next=next %}
     </li>
     <!-- then other backends from social_auth -->
     {% for backend in social_backends %}
@@ -35,9 +35,9 @@
                 {% csrf_token %}
                 <input type="hidden" name="assertion" value="" />
                 <a rel="nofollow" id="browserid" href="#" class="disabled"
-                   title="Wait for it..."><img
+                   title="{% trans 'Wait for it...' %}"><img
                    src="{{ STATIC_URL }}hyperkitty/img/login/persona-large-disabled.png"
-                   alt="Login using Persona" /></a>
+                   alt="{% trans 'Login using Persona' %}" /></a>
             </form>
         {% elif backend == "openid" %}
             <a class="socialaccount_provider openid" title="OpenID" href="#"><img
@@ -48,7 +48,7 @@
                 <div class="input-append">
                 <input type="text" class="input-large" name="openid_identifier"
                        placeholder="OpenID URL" />
-                <button type="submit" class="btn">Login with OpenID</button>
+                <button type="submit" class="btn">{% trans "Login with OpenID" %}</button>
                 </div>
             </form>
         {% else %}
@@ -64,7 +64,7 @@
 
 {% if use_internal_auth %}
 
-<h2>Login with username and password</h2>
+<h2>{% trans "Login with username and password" %}</h2>
 
 <form action="{{ request.path }}?next={{ next|urlencode }}"
       method="post" class="form-horizontal">

--- a/hyperkitty/templates/hyperkitty/message.html
+++ b/hyperkitty/templates/hyperkitty/message.html
@@ -19,7 +19,7 @@
         <div class="col-tn-2 message-back">
             <a href="{% url 'hk_thread' threadid=message.thread_id mlist_fqdn=mlist.name %}#{{message.message_id_hash}}">
                 <span class="fa fa-chevron-left icon"></span>
-                <span class="hidden-tn hidden-xs">thread</span>
+                <span class="hidden-tn hidden-xs">{% trans "thread" %}</span>
             </a>
         </div>
         <div class="col-tn-10">

--- a/hyperkitty/templates/hyperkitty/message.html
+++ b/hyperkitty/templates/hyperkitty/message.html
@@ -1,5 +1,6 @@
 {% extends "hyperkitty/base.html" %}
 {% load gravatar %}
+{% load i18n %}
 {% load hk_generic %}
 
 

--- a/hyperkitty/templates/hyperkitty/message_new.html
+++ b/hyperkitty/templates/hyperkitty/message_new.html
@@ -5,7 +5,7 @@
 
 
 {% block title %}
-Create a new thread - {{ mlist.display_name|default:mlist.name|escapeemail }} - {{ app_name|title }}
+{% trans "Create a new thread" %} - {{ mlist.display_name|default:mlist.name|escapeemail }} - {{ app_name|title }}
 {% endblock %}
 
 {% block content %}
@@ -18,8 +18,8 @@ Create a new thread - {{ mlist.display_name|default:mlist.name|escapeemail }} - 
 
         <div class="message-header">
             <h1>
-                Create a new thread
-                <small>in {{ mlist.display_name|default:mlist.name|escapeemail }}</small>
+                {% trans "Create a new thread" %}
+                <small>{% trans 'in' %} {{ mlist.display_name|default:mlist.name|escapeemail }}</small>
             </h1>
         </div>
 
@@ -36,8 +36,8 @@ Create a new thread - {{ mlist.display_name|default:mlist.name|escapeemail }} - 
                 {% csrf_token %}
                 {{ post_form|crispy }}
                 <p class="buttons">
-                    <button type="submit" class="submit btn btn-primary">Send</button>
-                    or <a class="cancel" href="{% url 'hk_archives_latest' mlist_fqdn=mlist.name %}">cancel</a>
+                    <button type="submit" class="submit btn btn-primary">{% trans "Send" %}</button>
+                    {% trans "or" %} <a class="cancel" href="{% url 'hk_archives_latest' mlist_fqdn=mlist.name %}">{% trans "cancel" %}</a>
                 </p>
             </form>
         </div>

--- a/hyperkitty/templates/hyperkitty/message_new.html
+++ b/hyperkitty/templates/hyperkitty/message_new.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 {% load crispy_forms_tags %}

--- a/hyperkitty/templates/hyperkitty/messages/like_form.html
+++ b/hyperkitty/templates/hyperkitty/messages/like_form.html
@@ -10,7 +10,7 @@
         <!-- if you like it, highlight thumbs up, disable thumbs down -->
         <a href="#cancelvote" class="vote" data-vote="0">
             <span class="fa fa-thumbs-up selected"></span>
-            <span class="hidden-tn hidden-xs">You like it (cancel)</span>
+            <span class="hidden-tn hidden-xs">{% trans "You like it (cancel)" %}</span>
         </a> / 
         <span class="fa fa-thumbs-down disabled"></span>
     {% elif object.myvote and object.myvote.value == -1 %}
@@ -18,18 +18,18 @@
         <span class="fa fa-thumbs-up disabled"></span> / 
         <a href="#cancelvote" class="vote" data-vote="0">
             <span class="fa fa-thumbs-down selected"></span>
-            <span class="hidden-tn hidden-xs">You dislike it (cancel)</span>
+            <span class="hidden-tn hidden-xs">{% trans "You dislike it (cancel)" %}</span>
         </a>
     {% else %}
-        <a class="youlike vote{% if not user.is_authenticated %} disabled" title="You must be logged-in to vote.{% endif %}"
+        <a class="youlike vote{% if not user.is_authenticated %} disabled" title="{% trans 'You must be logged-in to vote.' %}{% endif %}"
            href="#like" data-vote="1">
             <span class="fa fa-thumbs-o-up"></span>
-            <span class="hidden-tn hidden-xs hidden-sm">Like</span>
+            <span class="hidden-tn hidden-xs hidden-sm">{% trans "Like" %}</span>
         </a> / 
-        <a class="youdislike vote{% if not user.is_authenticated %} disabled" title="You must be logged-in to vote.{% endif %}"
+        <a class="youdislike vote{% if not user.is_authenticated %} disabled" title="{% trans 'You must be logged-in to vote.' %}{% endif %}"
            href="#dislike" data-vote="-1">
             <span class="fa fa-thumbs-o-down"></span>
-            <span class="hidden-tn hidden-xs hidden-sm">Dislike</span>
+            <span class="hidden-tn hidden-xs hidden-sm">{% trans "Dislike" %}</span>
         </a>
     {% endif %}
     </form>

--- a/hyperkitty/templates/hyperkitty/messages/like_form.html
+++ b/hyperkitty/templates/hyperkitty/messages/like_form.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 
     <form method="post" class="likeform"
           action="{% url 'hk_message_vote' mlist_fqdn=object.mailinglist_id message_id_hash=message_id_hash %}">

--- a/hyperkitty/templates/hyperkitty/messages/message.html
+++ b/hyperkitty/templates/hyperkitty/messages/message.html
@@ -14,7 +14,7 @@
                 <span class="name">
                     {% if email.sender.mailman_id %}
                     <a href="{% url 'hk_public_user_profile' user_id=email.sender.mailman_id %}"
-                       title="See {{ email.sender.name|escapeemail|escape }}'s profile"
+                       title="{% trans 'See the profile for {{ email.sender.name|escapeemail|escape }}' %}"
                        >{{email.sender.name|default:"(no name)"|escapeemail}}</a>
                     {% else %}
                        {{email.sender.name|default:"(no name)"|escapeemail}}
@@ -22,13 +22,13 @@
                 </span>
                 {% if use_mockups %}
                 <br>
-                <span class="rank">Rank 8</span>
+                <span class="rank">{% trans "Rank 8" %}</span>
                 {% endif %}
             </div>
         </div>
         {% if is_new %}
         <div class="right">
-            <i class="fa fa-envelope" title="Unread"></i>
+            <i class="fa fa-envelope" title="{% trans 'Unread' %}"></i>
         </div>
         {% endif %}
         <div class="email-date right">
@@ -47,13 +47,13 @@
             </span>
             {% endifchanged %}
             <div class="time">
-                <span title="Sender's time: {% localtime off %}{{email|date_with_senders_timezone|date:'DATETIME_FORMAT'}}{% endlocaltime %}">{{email.date|time:"TIME_FORMAT"}}</span>
+                <span title="{% trans 'Sender's time:' %} {% localtime off %}{{email|date_with_senders_timezone|date:'DATETIME_FORMAT'}}{% endlocaltime %}">{{email.date|time:"TIME_FORMAT"}}</span>
             </div>
 
         </div>
         <div class="messagelink right">
             (<a href="{% url 'hk_message_index' mlist_fqdn=email.mailinglist.name message_id_hash=email.message_id_hash %}"
-                title="{{ email.subject }}">permalink</a>)
+                title="{{ email.subject }}">{% trans "permalink" %}</a>)
         </div>
     </div> <!-- /email-header: gravatar, author-info, date, peramlink -->
 
@@ -63,7 +63,7 @@
 
     {% if unfolded and email.attachments.count %}
     <div class="attachments">
-        <p class="attachments">Attachments:</p>
+        <p class="attachments">{% trans "Attachments:" %}</p>
         <ul class="attachments-list list-unstyled">
         {% for attachment in email.attachments.all %}
             <li><a href="{% url 'hk_message_attachment' mlist_fqdn=email.mailinglist.name message_id_hash=email.message_id_hash counter=attachment.counter filename=attachment.name %}">{{attachment.name}}</a>
@@ -83,13 +83,13 @@
         {% if user.is_authenticated %}
         <a class="reply" href="#">
             <i class="fa fa-reply"></i>
-            Reply
+            {% trans "Reply" %}
         </a>
         {% else %}
-        <a class="reply reply-mailto" title="Login to reply online"
+        <a class="reply reply-mailto" title="{% trans 'Login to reply online' %}"
            href="mailto:{{ email.mailinglist.name }}?Subject={{ email.subject|reply_subject|urlencode }}&amp;In-Reply-To={{ email.message_id|urlencode }}">
             <i class="fa fa-reply"></i>
-            Reply
+            {% trans "Reply" %}
         </a>
         {% endif %}
 
@@ -97,7 +97,11 @@
         {% if not unfolded and email.attachments.count %}
         <div class="attachments dropdown">
             <a class="attachments" data-toggle="dropdown" href="#">
-                {{ email.attachments.count }} attachment{% if email.attachments.count > 1 %}s{% endif %}
+                {% blocktrans count attachments=email.attachments.count %}
+                {{ email.attachments.count }} attachment
+                {% plural %}
+                {{ email.attachments.count }} attachments
+                {% endblocktrans %}
                 <span class="caret"></span>
                 <!-- <i class="fa fa-caret-right"></i> -->
             </a>
@@ -120,11 +124,11 @@
                   action="{% url 'hk_message_reply' mlist_fqdn=email.mailinglist.name message_id_hash=email.message_id_hash %}">
                 {% csrf_token %}
                 <div class="reply-tools">
-                    <a class="btn quote" href="#">Quote</a>
-                    <label>{{ reply_form.newthread }} Create new thread</label>
+                    <a class="btn quote" href="#">{% trans "Quote" %}</a>
+                    <label>{{ reply_form.newthread }} {% trans "Create new thread" %}</label>
                     <a class="reply-mailto"
                        href="mailto:{{ email.mailinglist.name }}?Subject={{ email.subject|reply_subject|urlencode }}&amp;In-Reply-To={{ email.message_id|urlencode }}"
-                       >Use email software</a>
+                       >{% trans 'Use email software' %}</a>
                 </div>
                 {{ reply_form.non_field_errors }}
                 {% for field in reply_form %}
@@ -134,8 +138,8 @@
                 {% endfor %}
                 {# { reply_form.as_p } #}
                 <p class="buttons">
-                    <button type="submit" class="submit btn btn-primary">Send</button>
-                    or <a class="cancel" href="#">cancel</a>
+                    <button type="submit" class="submit btn btn-primary">{% trans "Send" %}</button>
+                    {% trans "or" %} <a class="cancel" href="#">{% trans "cancel" %}</a>
                 </p>
             </form>
         </div>

--- a/hyperkitty/templates/hyperkitty/messages/message.html
+++ b/hyperkitty/templates/hyperkitty/messages/message.html
@@ -1,3 +1,6 @@
+{% load url from future %}
+{% load kittystore %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 {% load tz %}

--- a/hyperkitty/templates/hyperkitty/messages/summary_message.html
+++ b/hyperkitty/templates/hyperkitty/messages/summary_message.html
@@ -20,7 +20,7 @@
                 <div class="gravatar col-tn-3 col-xs-2 col-lg-1">
                     {% if message.sender.mailman_id %}
                     <a href="{% url 'hk_public_user_profile' user_id=message.sender.mailman_id %}"
-                       title="See {{ message.sender.name|escapeemail|escape }}'s profile">
+                       title="{% trans 'See the profile for {{ message.sender.name|escapeemail|escape }}' %}">
                     {% endif %}
                     {% if message.sender.address %}
                     {% gravatar message.sender.address 40 %}
@@ -42,7 +42,7 @@
             </div>
             <div class="thread-info">
                 {% if message.tags|length %}
-                Tags:
+                {% trans "Tags:" %}
                 <ul class="list-unstyled tags">
                 {% for tag in message.tags %}
                     <li>

--- a/hyperkitty/templates/hyperkitty/messages/summary_message.html
+++ b/hyperkitty/templates/hyperkitty/messages/summary_message.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/overview.html
+++ b/hyperkitty/templates/hyperkitty/overview.html
@@ -1,5 +1,7 @@
 {% extends "hyperkitty/base.html" %}
 
+{% load i18n %}
+{% load url from future %}
 {% load hk_generic %}
 {% load gravatar %}
 

--- a/hyperkitty/templates/hyperkitty/overview.html
+++ b/hyperkitty/templates/hyperkitty/overview.html
@@ -32,25 +32,25 @@
 
         <ul class="nav nav-tabs hidden-sm hidden-md hidden-lg">
             <li class="active">
-                <a href="#home">Home</a>
+                <a href="#home">{% trans "Home" %}</a>
             </li>
             <li>
-                <a href="#stats">Stats</a>
+                <a href="#stats">{% trans "Stats" %}</a>
             </li>
             <li class="dropdown">
-                <a href="" id="navbarDiscussionsDrop" class="dropdown-toggle" data-toggle="dropdown">Discussions <b class="caret"></b></a>
+                <a href="" id="navbarDiscussionsDrop" class="dropdown-toggle" data-toggle="dropdown">{% trans "Discussions" %} <b class="caret"></b></a>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="navbarDiscussionsDrop">
                     <li>
-                        <a href="#most-recent" tabindex="-1">most recent</a>
+                        <a href="#most-recent" tabindex="-1">{% trans "most recent" %}</a>
                     </li>
                     <li>
-                        <a href="#most-popular" tabindex="-1">most popular</a>
+                        <a href="#most-popular" tabindex="-1">{% trans "most popular" %}</a>
                     </li>
                     <li>
-                        <a href="#most-active" tabindex="-1">most active</a>
+                        <a href="#most-active" tabindex="-1">{% trans "most active" %}</a>
                     </li>
                     <li>
-                        <a href="#by-category" tabindex="-1">by category</a>
+                        <a href="#by-category" tabindex="-1">{% trans "by category" %}</a>
                     </li>
                 </ul>
             </li>
@@ -64,11 +64,11 @@
             <form name="search" method="get" action="{% url 'hk_search' %}" class="searchbar col-tn-8 col-xs-4 hidden-sm hidden-md hidden-lg" role="search">
                 {% if mlist %}<input type="hidden" name="list" value="{{ mlist.name }}" />{% endif %}
                 <input id="nav-tab-search" name="query" type="text" class="form-control"
-                       placeholder="Search this list"
+                       placeholder="{% trans 'Search this list' %}"
                        {% if query %}value="{{ query }}"{% endif %}
                        />
             </form>
-            <div class="thread-new col-tn-6 col-sm-4" {% if not user.is_authenticated %}title="You must be logged-in to create a thread."{% endif %}>
+            <div class="thread-new col-tn-6 col-sm-4" {% if not user.is_authenticated %}title="{% trans 'You must be logged-in to create a thread.' %}"{% endif %}>
                 <a href="{% url "hk_message_new" mlist_fqdn=mlist.name %}"
                     class="btn btn-default{% if not user.is_authenticated %} disabled{% endif %}">
                     <i class="fa fa-plus"></i>
@@ -81,12 +81,12 @@
     {% if user.is_authenticated %}
     <div class="discussions pull-right col-tn-12 col-sm-8">
         <section id="flagged">
-            <h3>Discussions You've Flagged ({{ flagged_threads|length }}) <i class="fa fa-caret-right"></i></h3>
-            {% include "hyperkitty/fragments/overview_threads.html" with threads=flagged_threads empty="You have not flagged any discussions (yet)." %}
+            <h3>{% trans "Discussions You've Flagged" %} ({{ flagged_threads|length }}) <i class="fa fa-caret-right"></i></h3>
+            {% include "hyperkitty/fragments/overview_threads.html" with threads=flagged_threads empty="{% trans 'You have not flagged any discussions (yet).' %}" %}
         </section>
         <section id="posted-to">
-            <h3>Discussions You've Posted to ({{ threads_posted_to|length }}) <i class="fa fa-caret-right"></i></h3>
-            {% include "hyperkitty/fragments/overview_threads.html" with threads=threads_posted_to empty="You have not posted to this list (yet)." %}
+            <h3>{% trans "Discussions You've Posted to" %} ({{ threads_posted_to|length }}) <i class="fa fa-caret-right"></i></h3>
+            {% include "hyperkitty/fragments/overview_threads.html" with threads=threads_posted_to empty="{% trans 'You have not posted to this list (yet).' %}" %}
         </section>
     </div> <!-- /home, personalized threads lists -->
     {% endif %}
@@ -96,31 +96,31 @@
             <a id="most-recent"></a>
         </div>
         <section id="most-recent">
-            <h3>Recently active discussions</h3>
-            {% include "hyperkitty/fragments/overview_threads.html" with threads=most_active_threads empty="No discussions this month (yet)." %}
+            <h3>{% trans "Recently active discussions" %}</h3>
+            {% include "hyperkitty/fragments/overview_threads.html" with threads=most_active_threads empty="{% trans 'No discussions this month (yet).' %}" %}
         </section>
 
         <div class="anchor-link">
             <a id="most-popular"></a>
         </div>
         <section id="most-popular">
-            <h3>Most popular discussions</h3>
-            {% include "hyperkitty/fragments/overview_threads.html" with threads=pop_threads empty="No vote has been cast this month (yet)." %}
+            <h3>{% trans "Most popular discussions" %}</h3>
+            {% include "hyperkitty/fragments/overview_threads.html" with threads=pop_threads empty="{% trans 'No vote has been cast this month (yet).' %}" %}
         </section>
 
         <div class="anchor-link">
             <a id="most-active"></a>
         </div>
         <section id="most-active">
-            <h3>Most active discussions</h3>
-            {% include "hyperkitty/fragments/overview_threads.html" with threads=top_threads empty="No discussions this month (yet)." %}
+            <h3>{% trans "Most active discussions" %}</h3>
+            {% include "hyperkitty/fragments/overview_threads.html" with threads=top_threads empty="{% trans 'No discussions this month (yet).' %}" %}
         </section>
 
         <div class="anchor-link">
             <a id="by-category"></a>
         </div>
         <section id="by-category">
-            <h3>Discussion by category</h3>
+            <h3>{% trans "Discussion by category" %}</h3>
             {% for category, threads in threads_by_category.items %}
                 <h4 class="label{% if forloop.first %} first{% endif %}"
                    style="background-color:{{category.color}}"
@@ -133,13 +133,13 @@
                 {% if threads|length > 5 %}
                     <li>
                         <div class="bordered more-threads">
-                            <a href="">More...</a>
+                            <a href="">{% trans "More..." %}</a>
                         </div>
                     </li>
             {% endif %}
                 </ul>
             {% empty %}
-                <p>No category has been set this month (yet).</p>
+                <p>{% trans "No category has been set this month (yet)." %}</p>
             {% endfor %}
         </section>
     </div> <!-- /container, for thread lists -->
@@ -148,25 +148,25 @@
         <div class="anchor-link">
             <a id="stats"></a>
         </div>
-        <h3>Activity Summary</h3>
+        <h3>{% trans "Activity Summary" %}</h3>
         <div class="chart">
-            <p class="caption">Post volume over the past <strong>30</strong> days.</p>
-            <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+            <p class="caption">{% trans "Post volume over the past <strong>30</strong> days." %}</p>
+            <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
         </div>
 
         <p class="duration-text">
-            <span class="hidden-tn hidden-xs hidden-sm">The following statistics are from </span>
-            <span class="hidden-md hidden-lg">In </span>
-            the past <strong>30</strong> days:
+            <span class="hidden-tn hidden-xs hidden-sm">{% trans "The following statistics are from" %} </span>
+            <span class="hidden-md hidden-lg">{% trans "In" %}</span>
+            {% trans "the past <strong>30</strong> days:" %}
         </p>
         <ul class="list-stats list-unstyled">
-            <li><i class="icomoon participant"></i>{{ mlist.recent_participants_count }} participants</li>
-            <li><i class="icomoon discussion"></i>{{ mlist.recent_threads.count }} discussions</li>
+            <li><i class="icomoon participant"></i>{{ mlist.recent_participants_count }} {% trans "participants" %}</li>
+            <li><i class="icomoon discussion"></i>{{ mlist.recent_threads.count }} {% trans "discussions" %}</li>
         </ul>
 
         <div class="row">
         <section id="most-active-poster" class="col-tn-12 col-xs-6 col-sm-12">
-            <h3>Most active posters</h3>
+            <h3>{% trans "Most active posters" %}</h3>
             {% for poster in mlist.top_posters %}
             <div class="maker row">
                 <div class="inline-block maker-id col-tn-1">
@@ -179,7 +179,7 @@
                 <div class="gravatar-details inline-block col-tn-7 col-xs-6 col-md-7">
                     <ul class="list-unstyled">
                         <li><span class="maker-name">{{ poster.name }}</span></li>
-                        <li><span class="score">{{ poster.count }}</span> posts</li>
+                        <li><span class="score">{{ poster.count }}</span> {% trans "posts" %}</li>
                     </ul>
                 </div>
             </div>
@@ -189,7 +189,7 @@
 
         {% if top_author %}
         <section id="discussion-maker" class="col-tn-12 col-xs-6 col-sm-12">
-            <h3>Prominent posters</h3>
+            <h3>{% trans "Prominent posters" %}</h3>
             {% for author in top_author %}
             <div class="maker row">
                 <div class="inline-block maker-id col-tn-1">
@@ -204,7 +204,7 @@
                 <div class="gravatar-details inline-block col-tn-7 col-xs-6 col-md-7">
                     <ul class="list-unstyled">
                         <li><span class="maker-name">{{ author.name }}</span></li>
-                        <li><span class="score">+{{author.kudos}}</span> kudos</li>
+                        <li><span class="score">+{{author.kudos}}</span> {% trans "kudos" %}</li>
                     </ul>
                 </div>
             </div>

--- a/hyperkitty/templates/hyperkitty/paginator.html
+++ b/hyperkitty/templates/hyperkitty/paginator.html
@@ -10,7 +10,7 @@
     <li class="disabled">
         <a href="#">
     {% endif %}
-        &larr; {% if notbydate %}Previous{% else %}Newer{% endif %}
+        &larr; {% if notbydate %}{% trans "Previous" %}{% else %}{% trans "Newer" %}{% endif %}
         </a>
     </li>
 
@@ -31,7 +31,7 @@
     <li class="disabled">
         <a href="#">
     {% endif %}
-        {% if notbydate %}Next{% else %}Older{% endif %} &rarr;</a>
+        {% if notbydate %}{% trans "Next" %}{% else %}{% trans "Older" %}{% endif %} &rarr;</a>
     </li>
 </ul>
 </div>

--- a/hyperkitty/templates/hyperkitty/reattach.html
+++ b/hyperkitty/templates/hyperkitty/reattach.html
@@ -1,4 +1,7 @@
 {% extends "hyperkitty/base.html" %}
+
+{% load url from future %}
+{% load i18n %}
 {% load hk_generic %}
 
 

--- a/hyperkitty/templates/hyperkitty/reattach.html
+++ b/hyperkitty/templates/hyperkitty/reattach.html
@@ -3,7 +3,7 @@
 
 
 {% block title %}
-Reattach a thread - {{ mlist.display_name|default:mlist.name|escapeemail }} - {{ app_name|title }}
+{% trans "Reattach a thread" %} - {{ mlist.display_name|default:mlist.name|escapeemail }} - {{ app_name|title }}
 {% endblock %}
 
 {% block content %}
@@ -14,39 +14,39 @@ Reattach a thread - {{ mlist.display_name|default:mlist.name|escapeemail }} - {{
 
     <div class="col-md-7">
 
-        <h1>Re-attach a thread to another</h1>
+        <h1>{% trans "Re-attach a thread to another" %}</h1>
 
-        <p>Thread to re-attach:
+        <p>{% trans "Thread to re-attach:" %}
             <a href="{% url 'hk_thread' mlist_fqdn=mlist.name threadid=thread.thread_id %}"
                >{{ thread.subject }}</a>
-            (started {{ thread.starting_email.date }}, last active: {{ thread.date_active }})
+            ({% trans "started" %} {{ thread.starting_email.date }}, {% trans "last active:" %} {{ thread.date_active }})
         </p>
         <form action="{% url 'hk_thread_reattach_suggest' mlist_fqdn=mlist.name threadid=thread.thread_id %}"
               method="GET" class="search">
-            <p>Re-attach it to:
+            <p>{% trans "Re-attach it to:" %}
             <span class="input-append">
-            <input type="text" name="q" placeholder="Search for the parent thread"
-                /><button type="submit" class="btn btn-default">Search</button>
+            <input type="text" name="q" placeholder="{% trans 'Search for the parent thread' %}"
+                /><button type="submit" class="btn btn-default">{% trans "Search" %}</button>
             </span>
             </p>
         </form>
         <form action="" method="POST">
             {% csrf_token %}
             <ul class="list-unstyled suggestions">
-                <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+                <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
             </ul>
             <ul class="list-unstyled">
                 <li class="manual">
                     <input type="radio" name="parent" value="" />
-                    <label>this thread ID:
+                    <label>{% trans "this thread ID:" %}
                         <input type="text" name="parent-manual" size="32" placeholder="{{ thread.thread_id }}" />
                     </label>
                 </li>
             </ul>
             <p class="buttons">
-                <button type="submit" class="btn btn-primary">Do it</button> (there's no undoing!), or
+                <button type="submit" class="btn btn-primary">{% trans "Do it" %}</button> {% trans "(there's no undoing!), or" %}
                 <a href="{% url 'hk_thread' mlist_fqdn=mlist.name threadid=thread.thread_id %}"
-                   >go back to the thread</a>.
+                   >{% trans "go back to the thread</a>." %}
             </p>
         </form>
 

--- a/hyperkitty/templates/hyperkitty/register.html
+++ b/hyperkitty/templates/hyperkitty/register.html
@@ -11,7 +11,7 @@
 
 <div id="register">
 
-<h2>Register</h2>
+<h2>{% trans "Register" %}</h2>
 
 <form action="{{ request.path }}?next={{ next|urlencode }}" method="post" class="form-horizontal">
     {% crispy form %}

--- a/hyperkitty/templates/hyperkitty/search_results.html
+++ b/hyperkitty/templates/hyperkitty/search_results.html
@@ -4,7 +4,7 @@
 
 
 {% block title %}
-Search results for "{{ query }}"{% if mlist %} - {{ mlist.display_name|default:mlist.name|escapeemail }} {% endif %} - {{ app_name|title }}
+{% trans "Search results for" %} "{{ query }}"{% if mlist %} - {{ mlist.display_name|default:mlist.name|escapeemail }} {% endif %} - {{ app_name|title }}
 {% endblock %}
 
 {% block content %}
@@ -26,11 +26,11 @@ Search results for "{{ query }}"{% if mlist %} - {{ mlist.display_name|default:m
                         {{ mlist.name|until:"@" }}
                     {% endif %}
                 </a>
-                <small>search results</small>
+                <small>{% trans "search results" %}</small>
             {% else %}
-            <h1>Search results
+            <h1>{% trans "Search results" %}
             {% endif %}
-            <small>for query "{{ query }}"</small></h1>
+            <small>{% trans 'for query' %} "{{ query }}"</small></h1>
 
             {% if mlist.display_name %}
             <span class="list-address hidden-tn hidden-xs hidden-sm col-md-4">
@@ -40,7 +40,7 @@ Search results for "{{ query }}"{% if mlist %} - {{ mlist.display_name|default:m
             <ul class="list-unstyled list-stats col-tn-12 col-sm-6 col-md-4">
                 <li>
                     <span class="icomoon discussion"></span>
-                    {{ messages.paginator.count }} messages
+                    {{ messages.paginator.count }} {% trans "messages" %}
                 </li>
             </ul>
 
@@ -53,15 +53,15 @@ Search results for "{{ query }}"{% if mlist %} - {{ mlist.display_name|default:m
                 <select name="sort" id="sort-search" class="form-control">
                     <option value="score"
                         {% if sort_mode == "score" %}selected{% endif %}
-                        >sort by score</option>
+                        >{% trans "sort by score" %}</option>
                     <option value="date-desc"
                         {% if sort_mode == "date-desc" %}selected{% endif %}
-                        >sort by latest first</option>
+                        >{% trans "sort by latest first" %}</option>
                     <option value="date-asc"
                         {% if sort_mode == "date-asc" %}selected{% endif %}
-                        >sort by earliest first</option>
+                        >{% trans "sort by earliest first" %}</option>
                 </select>
-                <!--<button type="submit" class="btn btn-default btn-sm col-tn-3">Update</button>-->
+                <!--<button type="submit" class="btn btn-default btn-sm col-tn-3">{% trans "Update" %}</button>-->
             </form>
 
 
@@ -74,11 +74,11 @@ Search results for "{{ query }}"{% if mlist %} - {{ mlist.display_name|default:m
                 {% include "hyperkitty/messages/summary_message.html" with message=message.object %}
                 <!--</div>-->
             {% empty %}
-                <p>Sorry no email could be found for this query.</p>
+                <p>{% trans "Sorry no email could be found for this query." %}</p>
             {% endfor %}
         {% else %}
-            <p>Sorry but your query looks empty.</p>
-            <p style="font-style:italic;font-size:small;color:#ccc">these are not the messages you are looking for</p>
+            <p>{% trans "Sorry but your query looks empty." %}</p>
+            <p style="font-style:italic;font-size:small;color:#ccc">{% trans "these are not the messages you are looking for" %}</p>
         {% endif %}
 
         {% include "hyperkitty/paginator.html" with pager=messages notbydate=True %}

--- a/hyperkitty/templates/hyperkitty/search_results.html
+++ b/hyperkitty/templates/hyperkitty/search_results.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/thread.html
+++ b/hyperkitty/templates/hyperkitty/thread.html
@@ -28,7 +28,7 @@
                         {% if next_thread %}title="{{ next_thread.subject|strip_subject:mlist|escape }}"{% endif %}
                         href="{% url 'hk_thread' threadid=next_thread.thread_id mlist_fqdn=mlist.name %}">
                     <span class="fa fa-chevron-left"></span>
-                    <span class="hidden-tn hidden-xs">newer</span>
+                    <span class="hidden-tn hidden-xs">{% trans "newer" %}</span>
                 </a>
                {% endif %}
             </div>
@@ -42,7 +42,7 @@
                     href="{% url 'hk_thread' threadid=prev_thread.thread_id mlist_fqdn=mlist.name %}"
                     {% endif %}>
                     <span class="fa fa-chevron-right"></span>
-                    <span class="hidden-tn hidden-xs">older</span>
+                    <span class="hidden-tn hidden-xs">{% trans "older" %}</span>
                 </a>
             </div>
             <div class="thread-titles">
@@ -63,13 +63,13 @@
         <!-- nav tabs, for smaller screens -->
         <ul class="nav nav-tabs hidden-sm hidden-md hidden-lg">
             <li class="active">
-                <a href="#home">First Post</a>
+                <a href="#home">{% trans "First Post" %}</a>
             </li>
             <li>
-                <a href="#replies">Replies</a>
+                <a href="#replies">{% trans "Replies" %}</a>
             </li>
             <li>
-                <a href="#stats">Stats</a>
+                <a href="#stats">{% trans "Stats" %}</a>
             </li>
             <li class="dropdown">
                 {% include 'hyperkitty/threads/month_list.html' with show_dropdown=True %}
@@ -88,10 +88,10 @@
                     <p class="sort-mode">
                         {% if sort_mode == "date" %}
                         <a href="{% url 'hk_thread' threadid=thread.thread_id mlist_fqdn=mlist.name %}?sort=thread"
-                            >Show replies by thread</a>
+                            >{% trans "Show replies by thread" %}</a>
                         {% else %}
                         <a href="{% url 'hk_thread' threadid=thread.thread_id mlist_fqdn=mlist.name %}?sort=date"
-                            >Show replies by date</a>
+                            >{% trans "Show replies by date" %}</a>
                         {% endif %}
                     </p>
 
@@ -102,7 +102,7 @@
                         {% if is_bot %}
                             {% include 'hyperkitty/ajax/replies.html' %}
                         {% else %}
-                            <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+                            <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
                         {% endif %}
                     </div>
 

--- a/hyperkitty/templates/hyperkitty/thread.html
+++ b/hyperkitty/templates/hyperkitty/thread.html
@@ -1,5 +1,7 @@
 {% extends "hyperkitty/base.html" %}
 
+{% load i18n %}
+{% load url from future %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/thread_list.html
+++ b/hyperkitty/templates/hyperkitty/thread_list.html
@@ -35,15 +35,15 @@
                 {% if participants_count %}
                 <li>
                     <i class="icomoon participant"></i>
-                    {{ participants_count }} participants
+                    {{ participants_count }} {% trans "participants" %}
                 </li>
                 {% endif %}
                 <li>
                     <i class="icomoon discussion"></i>
-                    {{ threads.paginator.count }} discussions
+                    {{ threads.paginator.count }} {% trans "discussions" %}
                 </li>
             </ul>
-            <div class="thread-new right col-tn-6 col-xs-4" {% if not user.is_authenticated %}title="You must be logged-in to create a thread."{% endif %}>
+            <div class="thread-new right col-tn-6 col-xs-4" {% if not user.is_authenticated %}title="{% trans 'You must be logged-in to create a thread.' %}"{% endif %}>
                 <a href="{% url "hk_message_new" mlist_fqdn=mlist.name %}"
                     class="btn btn-default{% if not user.is_authenticated %} disabled{% endif %}">
                     <i class="fa fa-plus"></i>
@@ -55,7 +55,7 @@
         {% for thread in threads %}
             {% include "hyperkitty/threads/summary_thread_large.html" %}
         {% empty %}
-            <p>Sorry no email threads could be found {{ no_results_text }}.</p>
+            <p>{% trans "Sorry no email threads could be found" %} {{ no_results_text }}.</p>
         {% endfor %}
 
         {% include "hyperkitty/paginator.html" with pager=threads %}

--- a/hyperkitty/templates/hyperkitty/thread_list.html
+++ b/hyperkitty/templates/hyperkitty/thread_list.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/threads/category.html
+++ b/hyperkitty/templates/hyperkitty/threads/category.html
@@ -3,15 +3,15 @@
         <a class="label label-default{% if not user.is_authenticated %} disabled {% endif %}"
            {% if category %}style="background-color:{{category.color}}"{% endif %}
            {% if user.is_authenticated %}
-           title="Click to edit"
+           title="{% trans 'Click to edit' %}"
            {% else %}
-           title="You must be logged-in to edit."
+           title="{% trans 'You must be logged-in to edit.' %}"
            {% endif %}
            >
             {% if category %}
             {{ category.name|upper }}
             {% else %}
-            no category
+            {% trans "no category" %}
             {% endif %}
         </a>
         <form method="post" action="{% url 'hk_thread_set_category' mlist_fqdn=thread.mailinglist_id threadid=thread.thread_id %}">

--- a/hyperkitty/templates/hyperkitty/threads/category.html
+++ b/hyperkitty/templates/hyperkitty/threads/category.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 
         {{ category_form.errors.category }}
         <a class="label label-default{% if not user.is_authenticated %} disabled {% endif %}"

--- a/hyperkitty/templates/hyperkitty/threads/month_list.html
+++ b/hyperkitty/templates/hyperkitty/threads/month_list.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load hk_generic %}
 
 {% if show_dropdown %}

--- a/hyperkitty/templates/hyperkitty/threads/month_list.html
+++ b/hyperkitty/templates/hyperkitty/threads/month_list.html
@@ -1,7 +1,7 @@
 {% load hk_generic %}
 
 {% if show_dropdown %}
-<a href="" id="navbarMonthsListDrop" class="dropdown-toggle" data-toggle="dropdown">Go to <b class="caret"></b></a>
+<a href="" id="navbarMonthsListDrop" class="dropdown-toggle" data-toggle="dropdown">{% trans "Go to" %} <b class="caret"></b></a>
 <ul class="dropdown-menu right" role="menu" aria-labelledby="navbarMonthsListDrop">
     {% for year, months in months_list|sort %}
     <li role="presentation" class="dropdown-header disabled">

--- a/hyperkitty/templates/hyperkitty/threads/right_col.html
+++ b/hyperkitty/templates/hyperkitty/threads/right_col.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 {% load cache %}

--- a/hyperkitty/templates/hyperkitty/threads/right_col.html
+++ b/hyperkitty/templates/hyperkitty/threads/right_col.html
@@ -9,13 +9,13 @@
         <div class="col-tn-6">
             <span class="days-num">{{ days_inactive }}</span>
             <div class="days-text">
-                days inactive
+                {% trans "days inactive" %}
             </div>
         </div>
         <div class="col-tn-6">
             <span class="days-num">{{ days_old }}</span>
             <div class="days-text">
-                days old
+                {% trans "days old" %}
             </div>
         </div>
     </div> <!-- /Stats re: dates -->
@@ -28,16 +28,16 @@
 
     <div>
         <i class="icomoon discussion"></i>
-        {{ num_comments }} comments
+        {{ num_comments }} {% trans "comments" %}
     </div>
     <div>
         <i class="icomoon participant"></i>
-        {{ thread.participants_count }} participants
+        {{ thread.participants_count }} {% trans "participants" %}
     </div>
     <p class="unread">
         {% if user.is_authenticated %}
-        <i class="fa fa-envelope"></i> {{ unread_count }} unread
-        <span class="hidden-sm"> messages</span>
+        <i class="fa fa-envelope"></i> {{ unread_count }} {% trans "unread" %}
+        <span class="hidden-sm"> {% trans "messages" %}</span>
         {% endif %}
     </p>
 
@@ -46,17 +46,17 @@
         {% csrf_token %}
         <input type="hidden" name="action" value="{{ fav_action }}" />
         <p>
-            <a href="#AddFav" class="notsaved{% if not user.is_authenticated %} disabled" title="You must be logged-in to have favorites.{% endif %}">
-                <i class="fa fa-star"></i>Add to favorites</a>
+            <a href="#AddFav" class="notsaved{% if not user.is_authenticated %} disabled" title="{% trans 'You must be logged-in to have favorites.' %}{% endif %}">
+                <i class="fa fa-star"></i>{% trans "Add to favorites" %}</a>
             <a href="#RmFav" class="saved">
-                <i class="fa fa-star"></i>Remove from favorites</a>
+                <i class="fa fa-star"></i>{% trans "Remove from favorites" %}</a>
         </p>
     </form>
 
     {% if user.is_staff %}
     <p><i class="icon-resize-small"></i>
        <a href="{% url 'hk_thread_reattach' mlist_fqdn=mlist.name threadid=thread.thread_id %}"
-          >Reattach this thread</a>
+          >{% trans "Reattach this thread" %}</a>
     </p>
     {% endif %}
 
@@ -74,7 +74,7 @@
     </div>
     {% cache 86400 thread_participants thread.id %}
     <div id="participants">
-        <span id="participants_title">participants</span> ({{ thread.participants_count }})
+        <span id="participants_title">{% trans "participants" %}</span> ({{ thread.participants_count }})
         <ul class="list-unstyled">
             {% for participant in thread.participants|sort_by_name %}
             <li class="row">
@@ -90,10 +90,10 @@
 {% if user.is_authenticated %}
 <div id="unreadnavbar">
     <div>
-    Unreads: <span class="unreadindex">0</span>/{{unread_count}}
+    {% trans "Unreads:" %} <span class="unreadindex">0</span>/{{unread_count}}
     &nbsp;
-    Go to: <a href="#" class="nextunread" title="hotkey: j">next &darr;</a>
-         - <a href="#" class="prevunread" title="hotkey: k">prev &uarr;</a>
+    {% trans "Go to:" %} <a href="#" class="nextunread" title="hotkey: j">{% trans "next" %} &darr;</a>
+         - <a href="#" class="prevunread" title="hotkey: k">{% trans "prev" %} &uarr;</a>
     </div>
 </div>
 {% endif %}

--- a/hyperkitty/templates/hyperkitty/threads/summary_thread.html
+++ b/hyperkitty/templates/hyperkitty/threads/summary_thread.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load hk_generic %}
 
         <div class="thread row">

--- a/hyperkitty/templates/hyperkitty/threads/summary_thread.html
+++ b/hyperkitty/templates/hyperkitty/threads/summary_thread.html
@@ -12,7 +12,7 @@
                         </span>
                     {% endif %}
                     {% if thread|is_unread_by:request.user %}
-                        <i class="fa fa-envelope" title="New messages in this thread"></i>
+                        <i class="fa fa-envelope" title="{% trans 'New messages in this thread' %}"></i>
                     {% endif %}
                     {{ thread.subject|strip_subject:mlist }}
                 </a>

--- a/hyperkitty/templates/hyperkitty/threads/summary_thread_large.html
+++ b/hyperkitty/templates/hyperkitty/threads/summary_thread_large.html
@@ -8,10 +8,10 @@
                    href="{% url 'hk_thread' threadid=thread.thread_id mlist_fqdn=mlist.name %}"
                     >
                     {% if thread.favorite %}
-                    <i class="fa fa-star saved" title="Favorite"></i>
+                    <i class="fa fa-star saved" title="{% trans 'Favorite' %}"></i>
                     {% endif %}
                     {% if thread|is_unread_by:request.user %}
-                    <i class="fa fa-envelope" title="New messages in this thread"></i>
+                    <i class="fa fa-envelope" title="{% trans 'New messages in this thread' %}"></i>
                     {% endif %}
                     {{ starting_email.subject|strip_subject:mlist }}
                 </a>
@@ -45,10 +45,10 @@
                         </div>
                         <ul class="list-unstyled list-stats col-tn-12 col-sm-5">
                         <li>
-                            <i class="icomoon participant"></i> {{ thread.participants_count }} participants
+                            <i class="icomoon participant"></i> {{ thread.participants_count }} {% trans "participants" %}
                         </li>
                         <li>
-                            <i class="icomoon discussion"></i> {{ thread|num_comments }} comments
+                            <i class="icomoon discussion"></i> {{ thread|num_comments }} {% trans "comments" %}
                         </li>
                         </ul>
                     </div>
@@ -57,7 +57,7 @@
             <div class="thread-info">
                 <div class="tags">
                     {% if thread.tags|length %}
-                    Tags:
+                    {% trans "Tags:" %}
                     <ul class="list-unstyled tags">
                     {% for tag in thread.tags %}
                         <li>

--- a/hyperkitty/templates/hyperkitty/threads/summary_thread_large.html
+++ b/hyperkitty/templates/hyperkitty/threads/summary_thread_large.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/threads/tags.html
+++ b/hyperkitty/templates/hyperkitty/threads/tags.html
@@ -1,16 +1,16 @@
 
-        <span id="tag-title">tags </span>({{thread.tags.distinct.count}})
+        <span id="tag-title">{% trans "tags" %}</span>({{thread.tags.distinct.count}})
         <ul class="inline">
             {% for tag in thread.tags.distinct %}
             <li>
                 <a href="{#% url 'hk_search_tag' mlist_fqdn=thread.mailinglist.name tag=tag.name %#}"
-                   title="Search for tag {{ tag.name|escape }}">{{ tag.name }}</a>
+                   title="{% trans 'Search for tag' %} {{ tag.name|escape }}">{{ tag.name }}</a>
                 {% if user in tag.users.all %}
                 <form method="post" class="rmtag" action="{% url 'hk_tags' mlist_fqdn=thread.mailinglist.name threadid=thread.thread_id %}">
                     {% csrf_token %}
                     <input type="hidden" name="action" value="rm" />
                     <input type="hidden" name="tag" value="{{ tag.name|escape }}" />
-                    <a href="#rmtag" title="Remove">&times;</a>
+                    <a href="#rmtag" title="{% trans 'Remove' %}">&times;</a>
                 </form>
                 {% endif %}
                 {% if not forloop.last %} <span>|</span> {% endif %}

--- a/hyperkitty/templates/hyperkitty/threads/tags.html
+++ b/hyperkitty/templates/hyperkitty/threads/tags.html
@@ -1,3 +1,5 @@
+{% load url from future %}
+{% load i18n %}
 
         <span id="tag-title">{% trans "tags" %}</span>({{thread.tags.distinct.count}})
         <ul class="inline">

--- a/hyperkitty/templates/hyperkitty/user_posts.html
+++ b/hyperkitty/templates/hyperkitty/user_posts.html
@@ -4,7 +4,7 @@
 
 
 {% block title %}
-Messages by {{ fullname }}{% if mlist %} - {{ mlist.display_name|default:mlist.name|escapeemail }} {% endif %} - {{ app_name|title }}
+{% trans "Messages by" %} {{ fullname }}{% if mlist %} - {{ mlist.display_name|default:mlist.name|escapeemail }} {% endif %} - {{ app_name|title }}
 {% endblock %}
 
 {% block content %}
@@ -17,11 +17,11 @@ Messages by {{ fullname }}{% if mlist %} - {{ mlist.display_name|default:mlist.n
 
         <div class="thread-list-header page-header">
             {% if mlist %}
-            <h1>Messages by {{ fullname }}
-                <small>in {{ mlist.display_name|default:mlist.name|escapeemail }}</small>
+            <h1>{% trans "Messages by" %} {{ fullname }}
+                <small>{% trans "in" %} {{ mlist.display_name|default:mlist.name|escapeemail }}</small>
             </h1>
             {% else %}
-            <h1>Messages by {{ fullname }}</h1>
+            <h1>{% trans "Messages by" %} {{ fullname }}</h1>
             {% endif %}
             <ul class="thread-list-info">
                 {% if mlist.display_name %}
@@ -30,11 +30,11 @@ Messages by {{ fullname }}{% if mlist %} - {{ mlist.display_name|default:mlist.n
                 </li>
                 {% endif %}
                 <li class="discussion">
-                    {{ messages.paginator.count }} messages
+                    {{ messages.paginator.count }} {% trans "messages" %}
                 </li>
                 <li>
                     <a href="{% url 'hk_public_user_profile' user_id=user_id %}">
-                        Back to {{ fullname }}'s profile
+                        {% trans "Back to {{ fullname }}'s profile" %}
                     </a>
                 </li>
             </ul>
@@ -44,7 +44,7 @@ Messages by {{ fullname }}{% if mlist %} - {{ mlist.display_name|default:mlist.n
         {% for message in messages %}
             {% include "hyperkitty/messages/summary_message.html" %}
         {% empty %}
-            <p>Sorry no email could be found by this user.</p>
+            <p>{% trans "Sorry no email could be found by this user." %}</p>
         {% endfor %}
 
         {% include "hyperkitty/paginator.html" with pager=messages %}

--- a/hyperkitty/templates/hyperkitty/user_posts.html
+++ b/hyperkitty/templates/hyperkitty/user_posts.html
@@ -1,4 +1,6 @@
 {% extends "hyperkitty/base.html" %}
+{% load url from future %}
+{% load i18n %}
 {% load gravatar %}
 {% load hk_generic %}
 

--- a/hyperkitty/templates/hyperkitty/user_profile.html
+++ b/hyperkitty/templates/hyperkitty/user_profile.html
@@ -13,14 +13,14 @@
 <div class="row user-profile">
 <div class="col-tn-12">
 
-    <h1>User profile <small>for {{ user }}</small></h1>
+    <h1>{% trans "User profile" %} <small>{% trans "for" %} {{ user }}</small></h1>
 
     <div class="btn-group">
-        <a href="#account" class="btn btn-default active" data-toggle="tab" id="account-btn">Account</a>
-        <a href="#favorites" class="btn btn-default" data-toggle="tab" id="favorites-btn">Favorites</a>
-        <a href="#views" class="btn btn-default" data-toggle="tab" id="views-btn">Threads you have read</a>
-        <a href="#votes" class="btn btn-default" data-toggle="tab" id="votes-btn">Votes</a>
-        <a href="#subscriptions" class="btn btn-default" data-toggle="tab" id="subscriptions-btn">Subscriptions</a>
+        <a href="#account" class="btn btn-default active" data-toggle="tab" id="account-btn">{% trans "Account" %}</a>
+        <a href="#favorites" class="btn btn-default" data-toggle="tab" id="favorites-btn">{% trans "Favorites" %}</a>
+        <a href="#views" class="btn btn-default" data-toggle="tab" id="views-btn">{% trans "Threads you have read" %}</a>
+        <a href="#votes" class="btn btn-default" data-toggle="tab" id="votes-btn">{% trans "Votes" %}</a>
+        <a href="#subscriptions" class="btn btn-default" data-toggle="tab" id="subscriptions-btn">{% trans "Subscriptions" %}</a>
     </div>
 
     <div class="tab-content">
@@ -29,7 +29,7 @@
                 {% csrf_token %}
                 <div class="gravatar hidden-tn hidden-xs col-sm-4 col-sm-push-8 col-md-6 col-md-push-6 col-lg-7 col-lg-push-5">
                     <a href="{{ gravatar_url }}">{% gravatar user.email 150 %}</a>
-                    <p><a href="{{ gravatar_url }}">Edit on {{ gravatar_shortname }}</a></p>
+                    <p><a href="{{ gravatar_url }}">{% trans "Edit on" %} {{ gravatar_shortname }}</a></p>
                 </div>
 
                 <div class="col-tn-12 col-sm-8 col-sm-pull-4 col-md-6 col-md-pull-6 col-lg-5 col-lg-pull-7">
@@ -37,7 +37,7 @@
                         <tbody>
                             <tr class="gravatar hidden-sm hidden-md hidden-lg">
                                 <td><a href="{{ gravatar_url }}">{% gravatar user.email 60 %}</a></td>
-                                <td><a href="{{ gravatar_url }}">Edit on {{ gravatar_shortname }}</a></td>
+                                <td><a href="{{ gravatar_url }}">{% trans "Edit on" %} {{ gravatar_shortname }}</a></td>
                             </tr>
                             <tr>
                                 <th class="col-tn-6 col-sm-3">{% trans 'User name:' %}</th>
@@ -81,8 +81,8 @@
                 </div>
 
                 <p class="buttons col-tn-12">
-                    <button type="submit" class="submit btn btn-primary">Update</button>
-                    or <a href="#" class="cancel" onclick="document.forms[0].reset(); return false;">cancel</a>
+                    <button type="submit" class="submit btn btn-primary">{% trans "Update" %}</button>
+                    {% trans "or" %} <a href="#" class="cancel" onclick="document.forms[0].reset(); return false;">{% trans "cancel" %}</a>
                 </p>
             </form>
         </div> <!-- /tab pane, account info -->
@@ -100,22 +100,22 @@
             {% endfor %}
             </ul>
             {% else %}
-            <p>No favorites yet.</p>
+            <p>{% trans "No favorites yet." %}</p>
             {% endif %}
         </div> <!-- /tab pane, favorites -->
 
         <div id="views" class="tab-pane">
-            <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+            <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
             <div class="ajaxcontent" data-load-from="{% url 'hk_user_last_views' %}"></div>
         </div> <!-- /tab pane, threads you've read -->
 
         <div id="votes" class="tab-pane">
-            <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+            <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
             <div class="ajaxcontent" data-load-from="{% url 'hk_user_votes' %}"></div>
         </div> <!-- /tab pane, threads you've voted on -->
 
         <div id="subscriptions" class="tab-pane">
-            <img alt="Loading..." class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
+            <img alt="{% trans 'Loading...' %}" class="ajaxloader" src="{{ STATIC_URL }}hyperkitty/img/ajax-loader.gif" />
             <div class="ajaxcontent" data-load-from="{% url 'hk_user_subscriptions' %}"></div>
         </div> <!-- /tab pane, list subscriptions -->
 

--- a/hyperkitty/templates/hyperkitty/user_public_profile.html
+++ b/hyperkitty/templates/hyperkitty/user_public_profile.html
@@ -5,14 +5,14 @@
 
 
 {% block title %}
-{% trans 'User Profile' %} for {{ fullname }} - {{ app_name|title }}
+{% trans 'User Profile' %} {% trans "for" %} {{ fullname }} - {{ app_name|title }}
 {% endblock %}
 
 {% block content %}
 
 <div class="user-profile user-public-profile">
 
-    <h1>User profile <small>for {{ fullname }}</small></h1>
+    <h1>{% trans "User profile" %} <small>{% trans "for" %} {{ fullname }}</small></h1>
 
     <table class="table table-bordered table-striped user-data">
         <tbody>


### PR DESCRIPTION
Per [bug 30](https://fedorahosted.org/hyperkitty/ticket/30), I have systematically found all, or nearly all, user-visible occurrences of hard-coded English strings in the `hyperkitty/templates/hyperkitty/` directory and prepared them for translation/localisation/i18n as follows:

` {% trans 'English message' %}`

In some cases I have not been sure how to handle escaping, quoting, interaction with other variables, or pluralization; I'm happy to update this pull request in response to code review. Thanks.