### PR TITLE
wording in password/login help message

### DIFF
--- a/hyperkitty/templates/hyperkitty/login.html
+++ b/hyperkitty/templates/hyperkitty/login.html
@@ -74,8 +74,7 @@
 {% else %}
 
 <p class="text-center text-info">
-    Only external authentication sources are configured. To change your
-    password, use the corresponding source's facilities.
+{% trans "This website only lets you log in using one of these external authentication services. Check with your service for lost passwords or other login help." %}
 </p>
 
 {% endif %}


### PR DESCRIPTION
Improved phrasing in login.html template per my suggestion in [the bug](https://fedorahosted.org/hyperkitty/ticket/23), added translation syntax.