### PR TITLE
Remove unused function showtimes() and related numpy dependancy

### DIFF
--- a/hyperkitty.spec
+++ b/hyperkitty.spec
@@ -42,7 +42,6 @@ BuildRequires:  python-enum34
 BuildRequires:  python-django-haystack
 BuildRequires:  python-django-extensions
 BuildRequires:  python-lockfile
-BuildRequires:  numpy
 # Unit tests only
 BuildRequires:  python-beautifulsoup4
 BuildRequires:  python-mock

--- a/hyperkitty/lib/utils.py
+++ b/hyperkitty/lib/utils.py
@@ -152,14 +152,3 @@ def timeit(name):
         TIMES[name].append(spent)
         print("{}: {}".format(name, spent))
     LASTTIME = now
-def showtimes():
-    #global TIMES
-    import numpy
-    for name, values in TIMES.items():
-        if not values:
-            continue
-        values = numpy.array(values)
-        print("{} stats:".format(name))
-        print("- min: {}\n- max: {}\n- avg: {}\n- std: {}".format(
-            numpy.amin(values), numpy.amax(values),
-            numpy.mean(values), numpy.std(values) ))

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ REQUIRES = [
     "django-haystack>=2.1.0",
     "django-extensions>=1.3.7",
     "lockfile>=0.9.1",
-    "numpy>=1.8.2",
 ]
 try:
     import django


### PR DESCRIPTION
Hello,

Currently, hyperkitty requires numpy which is a very heavy dependency that makes mailman3 way more painful to install that it should be. After some investigation, it appears that it isn't required anymore according to this github search: https://github.com/hyperkitty/hyperkitty/search?utf8=%E2%9C%93&q=showtimes This patch removes it and removes numpy as a dependency.

Asking user to install a fortran compiler in 2015 for a mailing list service just doesn't feel right.

Kinds regards and thanks a lot for your contributions on mailman3, this new version is very welcomed,